### PR TITLE
fix: A bug about insert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ temp
 notes
 coverage.txt
 debug.test
+.idea

--- a/insert.go
+++ b/insert.go
@@ -80,6 +80,9 @@ func (r *Radix) InsertBytes(bs []byte, val ...interface{}) bool {
 
 			return prs
 		}
+		if v != bs[i] && match == 0 {
+			break
+		}
 	}
 
 	if match > 0 {


### PR DESCRIPTION
eg:
radix.Insert(roma)
radix.Insert(romb)
radix.Insert(abc)
result:
[]->m->[a, b]
[]->abc
ro lost